### PR TITLE
Fix EC2 user-data variable injection

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -50,7 +50,7 @@ resource "aws_instance" "pipeline" {
   iam_instance_profile        = aws_iam_instance_profile.pipeline_profile.name
 
   user_data = templatefile("${path.module}/ec2_user_data.sh.tpl", {
-    aws_region        = aws_region
+    aws_region        = var.aws_region
     postgres_host     = aws_db_instance.postgres.address
     postgres_port     = aws_db_instance.postgres.port
   })


### PR DESCRIPTION
## Summary
- pass aws region into EC2 user data correctly
- template user-data script to reference passed region and DB host/port

## Testing
- `terraform fmt -check` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*
- `curl -L -o /tmp/terraform.zip https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_amd64.zip` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_688bb4fd80d883308fe36e76b9e5319f