### PR TITLE
Escape shell variables in EC2 user data template

### DIFF
--- a/terraform/ec2_user_data.sh.tpl
+++ b/terraform/ec2_user_data.sh.tpl
@@ -23,16 +23,16 @@ export AWS_DEFAULT_REGION=${aws_region}
 # Clone or update the pipeline repo
 APP_DIR=/home/ubuntu/app
 REPO=https://github.com/ranovoxo/movie-data-pipeline-cloud.git
-mkdir -p "${APP_DIR}"
-chown ubuntu:ubuntu "${APP_DIR}"
+mkdir -p "$${APP_DIR}"
+chown ubuntu:ubuntu "$${APP_DIR}"
 
-if [ ! -d "${APP_DIR}/.git" ]; then
-    sudo -u ubuntu git clone "${REPO}" "${APP_DIR}"
+if [ ! -d "$${APP_DIR}/.git" ]; then
+    sudo -u ubuntu git clone "$${REPO}" "$${APP_DIR}"
 else
-    cd "${APP_DIR}"
+    cd "$${APP_DIR}"
     sudo -u ubuntu git pull origin main
 fi
-cd "${APP_DIR}"
+cd "$${APP_DIR}"
 
 # Retry helper for SSM SecureString fetches
 fetch() {


### PR DESCRIPTION
## Summary
- Prevent Terraform from interpreting shell variables as template variables in EC2 user data

## Testing
- `terraform fmt -recursive` *(fails: terraform not installed)*
- `apt-get update` *(fails: 403 Forbidden)*
- `curl -fsSL https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_amd64.zip -o /tmp/terraform.zip` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688bb760c3588330964f3304c4f9635e