### PR TITLE
Add S3 bucket for ML artifacts

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -18,3 +18,13 @@ output "rds_endpoint" {
   value       = aws_db_instance.postgres.endpoint
 }
 
+output "ml_artifacts_bucket_name" {
+  description = "Name of the S3 bucket for ML artifacts"
+  value       = aws_s3_bucket.ml_artifacts.bucket
+}
+
+output "ml_artifacts_bucket_arn" {
+  description = "ARN of the S3 bucket for ML artifacts"
+  value       = aws_s3_bucket.ml_artifacts.arn
+}
+

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,0 +1,62 @@
+resource "aws_s3_bucket" "ml_artifacts" {
+  bucket = var.ml_artifacts_bucket_name
+}
+
+resource "aws_s3_bucket_versioning" "ml_artifacts" {
+  bucket = aws_s3_bucket.ml_artifacts.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "ml_artifacts" {
+  bucket = aws_s3_bucket.ml_artifacts.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = "alias/aws/s3"
+      sse_algorithm     = "aws:kms"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "ml_artifacts" {
+  bucket                  = aws_s3_bucket.ml_artifacts.id
+  block_public_acls       = true
+  ignore_public_acls      = true
+  block_public_policy     = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "ml_artifacts" {
+  bucket = aws_s3_bucket.ml_artifacts.id
+
+  rule {
+    id     = "ml-artifacts-retention"
+    status = "Enabled"
+
+    filter {
+      prefix = ""
+    }
+
+    transition {
+      days          = 90
+      storage_class = "GLACIER"
+    }
+
+    expiration {
+      days = 365
+    }
+
+    noncurrent_version_transition {
+      noncurrent_days = 90
+      storage_class   = "GLACIER"
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 365
+    }
+  }
+}
+

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -4,6 +4,12 @@ variable "aws_region" {
   default     = "us-east-1"
 }
 
+variable "ml_artifacts_bucket_name" {
+  description = "Name of the S3 bucket for storing ML model artifacts"
+  type        = string
+  default     = "ml-artifacts-prod"
+}
+
 # variable "ami_id" {
 
 #  description = "AMI_ID for the EC2 instance (Ubuntu 20.04 LTS)"


### PR DESCRIPTION
## Summary
- create S3 bucket for ML model artifacts with versioning, KMS encryption, lifecycle rules, and public access blocking
- expose bucket name and ARN as outputs
- parameterize bucket name

## Testing
- `terraform fmt s3.tf variables.tf outputs.tf` *(fails: command not found)*
- `terraform validate` *(fails: command not found)*
- `apt-get update` *(fails: 403 errors; repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689f756ab6d48330850231ca0ae8a844