### PR TITLE
Use us-east-1 provider for ML artifacts bucket

### DIFF
--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,3 +1,8 @@
 provider "aws" {
   region = var.aws_region
 }
+
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,9 +1,11 @@
 resource "aws_s3_bucket" "ml_artifacts" {
-  bucket = var.ml_artifacts_bucket_name
+  provider = aws.us_east_1
+  bucket   = var.ml_artifacts_bucket_name
 }
 
 resource "aws_s3_bucket_versioning" "ml_artifacts" {
-  bucket = aws_s3_bucket.ml_artifacts.id
+  provider = aws.us_east_1
+  bucket   = aws_s3_bucket.ml_artifacts.id
 
   versioning_configuration {
     status = "Enabled"
@@ -11,7 +13,8 @@ resource "aws_s3_bucket_versioning" "ml_artifacts" {
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "ml_artifacts" {
-  bucket = aws_s3_bucket.ml_artifacts.id
+  provider = aws.us_east_1
+  bucket   = aws_s3_bucket.ml_artifacts.id
 
   rule {
     apply_server_side_encryption_by_default {
@@ -22,15 +25,17 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "ml_artifacts" {
 }
 
 resource "aws_s3_bucket_public_access_block" "ml_artifacts" {
-  bucket                  = aws_s3_bucket.ml_artifacts.id
-  block_public_acls       = true
-  ignore_public_acls      = true
-  block_public_policy     = true
+  provider               = aws.us_east_1
+  bucket                 = aws_s3_bucket.ml_artifacts.id
+  block_public_acls      = true
+  ignore_public_acls     = true
+  block_public_policy    = true
   restrict_public_buckets = true
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "ml_artifacts" {
-  bucket = aws_s3_bucket.ml_artifacts.id
+  provider = aws.us_east_1
+  bucket   = aws_s3_bucket.ml_artifacts.id
 
   rule {
     id     = "ml-artifacts-retention"


### PR DESCRIPTION
## Summary
- add dedicated `us-east-1` AWS provider alias
- use the US East provider for all ML artifacts S3 bucket resources

## Testing
- `terraform -version` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `curl -L -o /tmp/terraform.zip https://releases.hashicorp.com/terraform/1.7.5/terraform_1.7.5_linux_amd64.zip && unzip -d /tmp/terraform /tmp/terraform.zip && mv /tmp/terraform/terraform /usr/local/bin/terraform` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a36bef5a48833094509b9bc477ab5f